### PR TITLE
Fix links to 2aRon's guides

### DIFF
--- a/_data/external_guides.yml
+++ b/_data/external_guides.yml
@@ -172,10 +172,10 @@
   type: guides
   items:
     - spirit: Mud
-      link: https://boardgamegeek.com/thread/2955905/rising-heat-stone-and-sand-basic-strategy-and-full
+      link: https://boardgamegeek.com/thread/2959811/fathomless-mud-swamp-basic-strategy-and-full-solo
       credit: Sinderlin
     - spirit: Heat
-      link: https://boardgamegeek.com/thread/2959811/fathomless-mud-swamp-basic-strategy-and-full-solo
+      link: https://boardgamegeek.com/thread/2955905/rising-heat-stone-and-sand-basic-strategy-and-full
       credit: Sinderlin
 
 - author: ArtEntre


### PR DESCRIPTION
Oops, the links were crossed. Mud's link went to Heat's guide and vice versa :D