### PR TITLE
Update external_guides.yml

### DIFF
--- a/_data/external_guides.yml
+++ b/_data/external_guides.yml
@@ -243,6 +243,30 @@
     link: https://youtu.be/oh1PrLgempk?si=0di8dd2yuySzjlT3
     site: YouTube
     spirit: Waters
+    
+- author: Gnawing Rootbiters
+  items:
+  - credit: Sinderlin
+    is_collection: false
+    link: https://www.youtube.com/watch?v=fl1OdDXqniI
+    site: YouTube
+    spirit: Mist
+  - credit: Sinderlin
+    is_collection: false
+    link: https://www.youtube.com/watch?v=NH4JYMpFSbA
+    site: YouTube
+    spirit: Starlight
+  - credit: Sinderlin
+    is_collection: false
+    link: https://youtu.be/dheSjXZqHQY
+    site: YouTube
+    spirit: Vengeance
+  - credit: Sinderlin
+    is_collection: false
+    link: https://youtu.be/ipQ7CZYV7EQ
+    site: YouTube
+    spirit: Waters
+    
 - author: Carlo Gon
   items:
   - is_collection: false


### PR DESCRIPTION
Adds guides from the Gnawing Rootbiters Youtube channel. I know the guides are technically authored by two different people but since they're publishing them as a team on one channel, I felt like keeping them together in one spot was more important than precise attribution.